### PR TITLE
Exception thrown when content type doesn't have character set

### DIFF
--- a/xml-http-request.ts
+++ b/xml-http-request.ts
@@ -459,7 +459,9 @@ export class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	}
 	
 	private _parseResponseEncoding() {
-		return /;\s*charset=(.*)$/.exec(this._responseHeaders['content-type'] || '')[1] || 'utf-8';
+		var hdr = this._responseHeaders['content-type'] || '';
+		var ret = /;\s*charset=(.*)$/.exec(hdr);
+		return Array.isArray(ret) ? ret[1] : 'utf-8';
 	}
 }
 


### PR DESCRIPTION
This patch fixes an exception occuring when the content type in the headers does not contain a character set.  The exception generated results from attempting to dereference an array on null