### PR TITLE
initializing buffers in a non-obsolete way

### DIFF
--- a/test/send.spec.ts
+++ b/test/send.spec.ts
@@ -101,7 +101,7 @@ test('XMLHttpRequest #send works with ArrayBuffers', async t => {
 
 test('XMLHttpRequest #send works with node.js Buffers', async t => {
 	const xhr = t.context.xhr;
-	const buffer = new Buffer(PNGUint8Array.length);
+	const buffer = Buffer.alloc(PNGUint8Array.length);
 	for (let i = 0; i < PNGUint8Array.length; i++) { buffer.writeUInt8(PNGUint8Array[i], i); }
 	t.plan(2);
 	

--- a/xml-http-request-upload.ts
+++ b/xml-http-request-upload.ts
@@ -22,16 +22,16 @@ export class XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
 			if (data.length !== 0) {
 				this._contentType = 'text/plain;charset=UTF-8';
 			}
-			this._body = new Buffer(data, 'utf-8');
+			this._body = Buffer.from(data, 'utf-8');
 		} else if (Buffer.isBuffer(data)) {
 			this._body = data;
 		} else if (data instanceof ArrayBuffer) {
-			const body = new Buffer(data.byteLength);
+			const body = Buffer.alloc(data.byteLength);
 			const view = new Uint8Array(data);
 			for (let i = 0; i < data.byteLength; i++) { body[i] = view[i]; }
 			this._body = body;
 		} else if (data.buffer && data.buffer instanceof ArrayBuffer) {
-			const body = new Buffer(data.byteLength);
+			const body = Buffer.alloc(data.byteLength);
 			const offset = data.byteOffset;
 			const view = new Uint8Array(data.buffer);
 			for (let i = 0; i < data.byteLength; i++) { body[i] = view[i + offset]; }

--- a/xml-http-request.ts
+++ b/xml-http-request.ts
@@ -326,7 +326,7 @@ export class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	private _onHttpResponseData(response: IncomingMessage, data: string | Buffer) {
 		if (this._response !== response) { return; }
 		
-		this._responseParts.push(new Buffer(data as any));
+		this._responseParts.push(Buffer.from(data as any));
 		this._loadedBytes += data.length;
 		
 		if (this.readyState !== XMLHttpRequest.LOADING) {


### PR DESCRIPTION
This fix will remove the following warning:

```
(node:14846) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues.
```